### PR TITLE
fix: change indentation size to support nested lists

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ charset = utf-8
 [*.{js,py,md,json,yml}]
 indent_style = space
 indent_size = 2
+
+[*.md]
+indent_size = 4

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
   "default": true,
-  "MD007": { "indent": 2 },
+  "MD007": { "indent": 4 },
   "no-hard-tabs": false,
   "whitespace": false,
   "MD013": false,

--- a/docs/server/guides/moderation/moderation.md
+++ b/docs/server/guides/moderation/moderation.md
@@ -12,25 +12,25 @@ Before your server opens, set the rules. In a small server with friends, you agr
 
 Below is a list of actions that are prohibited on many servers:
 
-- Chat
-  - Cursing/racism
-  - Spam
-  - Advertising
-  - Sharing private information
-  - Threatening players
-  - Inappropriate name/skin
-- Game
-  - Inappropriate Buildings
-  - Griefing
-  - Anti-afk system
-  - Lagging
-- Hacks
-  - X-ray
-  - Hacked Client
-  - Bug abuse
-- Server
-  - Corrupt making inventories
-  - Crashing server
+-   Chat
+    -   Cursing/racism
+    -   Spam
+    -   Advertising
+    -   Sharing private information
+    -   Threatening players
+    -   Inappropriate name/skin
+-   Game
+    -   Inappropriate Buildings
+    -   Griefing
+    -   Anti-afk system
+    -   Lagging
+-   Hacks
+    -   X-ray
+    -   Hacked Client
+    -   Bug abuse
+-   Server
+    -   Corrupt making inventories
+    -   Crashing server
 
 With a server for larger audiences, you should also share the rules. Publish them on your website, put them in the spawn or give players in the lobby a book. This way the players know what is and what is not allowed on your server. This also stops the excuse: "I didn't know this was forbidden".
 

--- a/docs/server/guides/other/remote_server_management.md
+++ b/docs/server/guides/other/remote_server_management.md
@@ -4,24 +4,6 @@ The goal of this tutorial is to give you everything you need to manage your serv
 
 ---
 
-## Table of Contents
-
-- [Command Line Access (SSH)](#command-line-access-ssh)
-  - [PuTTY](#putty)
-    - [Shortcut Setup](#shortcut-setup)
-- [tmux](#tmux)
-  - [Attaching Sessions](#attaching-sessions)
-  - [Sending keys](#sending-keys)
-  - [Shortcuts](#shortcuts)
-- [File Management (FileZilla)](#file-management-filezilla)
-  - [Connecting](#connecting)
-  - [Navigation](#navigation)
-  - [Transferring Files](#transferring-files)
-  - [Editing Files](#editing-files)
-- [Conclusion](#conclusion)
-
----
-
 ## Command Line Access (SSH)
 
 Since a lot of interaction with a Minecraft server is through its command line terminal, your primary tool for interacting with your remote server will be SSH.
@@ -46,9 +28,9 @@ Don't worry, though—you don't have to learn any of that. One of the best parts
 
 1. Find the default PuTTY shortcuts.
 
-   - Press the Windows key `Win` and search for "putty". Right-click on the app result, and click "Open file location".
+    - Press the Windows key `Win` and search for "putty". Right-click on the app result, and click "Open file location".
 
-   - The default location for this is `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\PuTTY (64-bit)`.
+    - The default location for this is `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\PuTTY (64-bit)`.
 
 2. Copy the "PuTTY" shortcut, and paste it in the directory `C:\Users\<username>\AppData\Roaming\Microsoft\Windows\Start Menu\Programs`. You can rename it to something recognizable by you, such as "SSH Minecraft Server".
 
@@ -56,9 +38,9 @@ Don't worry, though—you don't have to learn any of that. One of the best parts
 
 4. In "Target", enter this: `"C:\Program Files\PuTTY\putty.exe" -ssh <username>@<IP address> -pw <password>`. Be sure to add your proper credentials. You may need to change your path to `putty.exe` if you have it installed in a different location.
 
-   - This gives PuTTY arguments to use when you start it. The arguments are the IP address/user you want to connect to, and the password to use for that user.
+    - This gives PuTTY arguments to use when you start it. The arguments are the IP address/user you want to connect to, and the password to use for that user.
 
-   - Note that this stores your password in plaintext. If you don't want that, you can remove the `-pw <password>` argument, and it will prompt you to enter your password each time you run the shortcut.
+    - Note that this stores your password in plaintext. If you don't want that, you can remove the `-pw <password>` argument, and it will prompt you to enter your password each time you run the shortcut.
 
 That's it! You now have a shortcut for PuTTY set up. You can open the shortcut by pressing the Windows key `Win` and searching for its name—this makes it super easy to open. You can use this SSH connection to do anything on the command-line that you'd be able to do with physical keyboard, mouse, and monitor access.
 
@@ -96,11 +78,11 @@ To detach the tmux session, returning to the regular Linux terminal, use the key
 
 To send commands to the session without switching to it, use the command `tmux send-keys -t <session name>.0 "<command>" ENTER`. There's a lot to unpack in that command:
 
-- You're using the tmux command `send-keys` to send, well, key press input to a tmux session.
+-   You're using the tmux command `send-keys` to send, well, key press input to a tmux session.
 
-- You're using `-t <session name>.0` to specify what tmux session you're referring to. The `-t` argument is used in tmux commands to do this. The `.0` at the end of the session name specifies the window you want to send the keys to. This tutorial doesn't use tmux windows, but they're pretty simple: you can have multiple windows in one tmux session, switching between them.
+-   You're using `-t <session name>.0` to specify what tmux session you're referring to. The `-t` argument is used in tmux commands to do this. The `.0` at the end of the session name specifies the window you want to send the keys to. This tutorial doesn't use tmux windows, but they're pretty simple: you can have multiple windows in one tmux session, switching between them.
 
-- `"<command>" ENTER` has the actual keys you want sent to the tmux session. A single-line command is stored in the quotation marks, and by sending the key `ENTER` at the end you'll cause the session to actually run the command. You should be able to repeat this syntax several times to send multiple commands, or you can run the entire `tmux send-keys` command several times with a different command contained each time.
+-   `"<command>" ENTER` has the actual keys you want sent to the tmux session. A single-line command is stored in the quotation marks, and by sending the key `ENTER` at the end you'll cause the session to actually run the command. You should be able to repeat this syntax several times to send multiple commands, or you can run the entire `tmux send-keys` command several times with a different command contained each time.
 
 Here's an example of this:
 
@@ -136,9 +118,9 @@ Here, you can specify the IP address and your credentials, very similar to SSH. 
 
 Now, you'll be able to view two locations:
 
-- Files in a local directory on your computer
+-   Files in a local directory on your computer
 
-- Files in a remote directory on the remote server
+-   Files in a remote directory on the remote server
 
 You can navigate through each by entering a direct location in the text boxes above the directory viewers or by double-clicking on a directory (double-click `..` to go up one directory).
 
@@ -146,9 +128,9 @@ You can navigate through each by entering a direct location in the text boxes ab
 
 There are several methods for transferring files using FileZilla:
 
-- Select and drag files from one side to the other to transfer all of the selected files.
+-   Select and drag files from one side to the other to transfer all of the selected files.
 
-- Double-click a file to transfer that single file. Note this behavior on a double-click; double-clicking doesn't run a file or open it in an editor.
+-   Double-click a file to transfer that single file. Note this behavior on a double-click; double-clicking doesn't run a file or open it in an editor.
 
 ### Editing Files
 


### PR DESCRIPTION
# Description

Changed the indentation size to 4 spaces in order to support nested lists. The markdown interpreter which MkDocs is using only interprets lists as nested, when 4 spaces are used.

## Checklist

- [x] My contributions follows the style guidelines of this project
- [x] I have performed a self-review of my own contributions (checked for spelling errors, proper linking, etc)
- [x] I have run linting on my branch before submitting the PR
